### PR TITLE
Add interactive capsule button example

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Capsule Button</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <button class="capsule" id="explodeBtn">Click Me</button>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,15 @@
+const btn = document.getElementById('explodeBtn');
+
+btn.addEventListener('click', function (e) {
+    const circle = document.createElement('span');
+    circle.classList.add('explode');
+    this.appendChild(circle);
+
+    const rect = this.getBoundingClientRect();
+    const size = Math.max(rect.width, rect.height) * 2;
+    circle.style.width = circle.style.height = size + 'px';
+    circle.style.left = (e.clientX - rect.left - size / 2) + 'px';
+    circle.style.top = (e.clientY - rect.top - size / 2) + 'px';
+
+    circle.addEventListener('animationend', () => circle.remove());
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,42 @@
+body {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100vh;
+    margin: 0;
+    background: #f0f0f0;
+    font-family: sans-serif;
+}
+
+.capsule {
+    background: #3498db;
+    color: #fff;
+    border: none;
+    padding: 12px 30px;
+    border-radius: 25px;
+    font-size: 16px;
+    cursor: pointer;
+    position: relative;
+    overflow: hidden;
+    transition: opacity 0.3s;
+}
+
+.capsule:hover {
+    opacity: 0.6;
+}
+
+.capsule span.explode {
+    position: absolute;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.8);
+    transform: scale(0);
+    pointer-events: none;
+    animation: explode 0.6s linear;
+}
+
+@keyframes explode {
+    to {
+        transform: scale(2);
+        opacity: 0;
+    }
+}


### PR DESCRIPTION
## Summary
- add a small web example with a capsule button
- style the button with hover fade and click explosion

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685874b92cdc8333a27fafac7eefb575